### PR TITLE
Enable localstorage

### DIFF
--- a/app/src/main/java/lu/geoportail/map/MainActivity.kt
+++ b/app/src/main/java/lu/geoportail/map/MainActivity.kt
@@ -37,6 +37,7 @@ class MainActivity : Activity() {
         val view = WebView(applicationContext)
         val settings = view.settings
         val appCachePath = this.cacheDir.absolutePath
+        settings.domStorageEnabled = true
         settings.allowFileAccess = true
         settings.javaScriptEnabled = true
         settings.setAppCachePath(appCachePath)


### PR DESCRIPTION
Localstorage is used for state management and storing custom style when not logged in.
See https://jira.camptocamp.com/browse/GSLUX-276.